### PR TITLE
angular-components: allow version ranges for peerDependencies

### DIFF
--- a/libs/angular-components/package.json
+++ b/libs/angular-components/package.json
@@ -7,10 +7,10 @@
     "directory": "libs/angular-components"
   },
   "peerDependencies": {
-    "@angular/common": "17.3.9",
-    "@angular/core": "17.3.9",
-    "@angular/forms": "17.3.9",
-    "@angular/cdk": "17.3.9"
+    "@angular/common": "^17.3.9",
+    "@angular/core": "^17.3.9",
+    "@angular/forms": "^17.3.9",
+    "@angular/cdk": "^17.3.9"
   },
   "dependencies": {
     "@finastra/angular-theme": "4.2.0"


### PR DESCRIPTION
version ranges allow consuming projects to update the minor/patch versions of the angular dependencies