### PR TITLE
Set line-height & letter-spacing

### DIFF
--- a/libs/angular-theme/lib/core/typography/_typography.scss
+++ b/libs/angular-theme/lib/core/typography/_typography.scss
@@ -9,67 +9,97 @@ $typography-config: mat.m2-define-typography-config(
     mat.m2-define-typography-level(
       $font-family: map.get(fds-variables.$properties, 'headline-1', 'font-family'),
       $font-size: map.get(fds-variables.$properties, 'headline-1', 'font-size'),
-      $font-weight: map.get(fds-variables.$properties, 'headline-1', 'font-weight')
+      $font-weight: map.get(fds-variables.$properties, 'headline-1', 'font-weight'),
+      $line-height: map.get(fds-variables.$properties, 'headline-1', 'line-height'),
+      $letter-spacing: map.get(fds-variables.$properties, 'headline-1', 'letter-spacing')
     ),
   $headline-2:
     mat.m2-define-typography-level(
       $font-family: map.get(fds-variables.$properties, 'headline-2', 'font-family'),
       $font-size: map.get(fds-variables.$properties, 'headline-2', 'font-size'),
-      $font-weight: map.get(fds-variables.$properties, 'headline-2', 'font-weight')
+      $font-weight: map.get(fds-variables.$properties, 'headline-2', 'font-weight'),
+      $line-height: map.get(fds-variables.$properties, 'headline-2', 'line-height'),
+      $letter-spacing: map.get(fds-variables.$properties, 'headline-2', 'letter-spacing')
     ),
   $headline-3:
     mat.m2-define-typography-level(
       $font-family: map.get(fds-variables.$properties, 'headline-3', 'font-family'),
       $font-size: map.get(fds-variables.$properties, 'headline-3', 'font-size'),
-      $font-weight: map.get(fds-variables.$properties, 'headline-3', 'font-weight')
+      $font-weight: map.get(fds-variables.$properties, 'headline-3', 'font-weight'),
+      $line-height: map.get(fds-variables.$properties, 'headline-3', 'line-height'),
+      $letter-spacing: map.get(fds-variables.$properties, 'headline-3', 'letter-spacing')
     ),
   $headline-4:
     mat.m2-define-typography-level(
       $font-family: map.get(fds-variables.$properties, 'headline-4', 'font-family'),
       $font-size: map.get(fds-variables.$properties, 'headline-4', 'font-size'),
-      $font-weight: map.get(fds-variables.$properties, 'headline-4', 'font-weight')
+      $font-weight: map.get(fds-variables.$properties, 'headline-4', 'font-weight'),
+      $line-height: map.get(fds-variables.$properties, 'headline-4', 'line-height'),
+      $letter-spacing: map.get(fds-variables.$properties, 'headline-4', 'letter-spacing')
     ),
   $headline-5:
     mat.m2-define-typography-level(
       $font-family: map.get(fds-variables.$properties, 'headline-5', 'font-family'),
       $font-size: map.get(fds-variables.$properties, 'headline-5', 'font-size'),
-      $font-weight: map.get(fds-variables.$properties, 'headline-5', 'font-weight')
+      $font-weight: map.get(fds-variables.$properties, 'headline-5', 'font-weight'),
+      $line-height: map.get(fds-variables.$properties, 'headline-5', 'line-height'),
+      $letter-spacing: map.get(fds-variables.$properties, 'headline-5', 'letter-spacing')
     ),
   $headline-6:
     mat.m2-define-typography-level(
       $font-family: map.get(fds-variables.$properties, 'headline-6', 'font-family'),
       $font-size: map.get(fds-variables.$properties, 'headline-6', 'font-size'),
-      $font-weight: map.get(fds-variables.$properties, 'headline-6', 'font-weight')
+      $font-weight: map.get(fds-variables.$properties, 'headline-6', 'font-weight'),
+      $line-height: map.get(fds-variables.$properties, 'headline-6', 'line-height'),
+      $letter-spacing: map.get(fds-variables.$properties, 'headline-6', 'letter-spacing')
     ),
   $subtitle-1:
     mat.m2-define-typography-level(
       $font-family: map.get(fds-variables.$properties, 'subtitle-1', 'font-family'),
       $font-size: map.get(fds-variables.$properties, 'subtitle-1', 'font-size'),
-      $font-weight: map.get(fds-variables.$properties, 'subtitle-1', 'font-weight')
+      $font-weight: map.get(fds-variables.$properties, 'subtitle-1', 'font-weight'),
+      $line-height: map.get(fds-variables.$properties, 'subtitle-1', 'line-height'),
+      $letter-spacing: map.get(fds-variables.$properties, 'subtitle-1', 'letter-spacing')
     ),
   $subtitle-2:
     mat.m2-define-typography-level(
       $font-family: map.get(fds-variables.$properties, 'subtitle-2', 'font-family'),
       $font-size: map.get(fds-variables.$properties, 'subtitle-2', 'font-size'),
-      $font-weight: map.get(fds-variables.$properties, 'subtitle-2', 'font-weight')
+      $font-weight: map.get(fds-variables.$properties, 'subtitle-2', 'font-weight'),
+      $line-height: map.get(fds-variables.$properties, 'subtitle-2', 'line-height'),
+      $letter-spacing: map.get(fds-variables.$properties, 'subtitle-2', 'letter-spacing')
     ),
   $body-1:
     mat.m2-define-typography-level(
       $font-family: map.get(fds-variables.$properties, 'body-1', 'font-family'),
       $font-size: map.get(fds-variables.$properties, 'body-1', 'font-size'),
-      $font-weight: map.get(fds-variables.$properties, 'body-1', 'font-weight')
+      $font-weight: map.get(fds-variables.$properties, 'body-1', 'font-weight'),
+      $line-height: map.get(fds-variables.$properties, 'body-1', 'line-height'),
+      $letter-spacing: map.get(fds-variables.$properties, 'body-1', 'letter-spacing')
     ),
   $body-2:
     mat.m2-define-typography-level(
       $font-family: map.get(fds-variables.$properties, 'body-2', 'font-family'),
       $font-size: map.get(fds-variables.$properties, 'body-2', 'font-size'),
-      $font-weight: map.get(fds-variables.$properties, 'body-2', 'font-weight')
+      $font-weight: map.get(fds-variables.$properties, 'body-2', 'font-weight'),
+      $line-height: map.get(fds-variables.$properties, 'body-2', 'line-height'),
+      $letter-spacing: map.get(fds-variables.$properties, 'body-2', 'letter-spacing')
     ),
   $caption:
     mat.m2-define-typography-level(
       $font-family: map.get(fds-variables.$properties, 'caption', 'font-family'),
       $font-size: map.get(fds-variables.$properties, 'caption', 'font-size'),
-      $font-weight: map.get(fds-variables.$properties, 'caption', 'font-weight')
+      $font-weight: map.get(fds-variables.$properties, 'caption', 'font-weight'),
+      $line-height: map.get(fds-variables.$properties, 'caption', 'line-height'),
+      $letter-spacing: map.get(fds-variables.$properties, 'caption', 'letter-spacing')
+    ),
+  $button:
+    mat.m2-define-typography-level(
+      $font-family: map.get(fds-variables.$properties, 'button-1', 'font-family'),
+      $font-size: map.get(fds-variables.$properties, 'button-1', 'font-size'),
+      $font-weight: map.get(fds-variables.$properties, 'button-1', 'font-weight'),
+      $line-height: map.get(fds-variables.$properties, 'button-1', 'line-height'),
+      $letter-spacing: map.get(fds-variables.$properties, 'button-1', 'letter-spacing')
     )
 );
 @include mat.typography-hierarchy($typography-config);


### PR DESCRIPTION
The --mat-* css variables associated with line-height and letter-spacing styles are not correlated with the --fds-* css variables. This causes css classes which reference the --mat-* variables to be incorrect.

Example of current values:

--mat-form-field-container-text-line-height: `1rem`;
--mat-form-field-container-text-size: 1rem;
--mat-form-field-container-text-tracking: `normal`;

--mat-form-field-subscript-text-line-height: `.75rem`;
--mat-form-field-subscript-text-size: .75rem;
--mat-form-field-subscript-text-tracking: `normal`;

Example of corrected values:

--mat-form-field-container-text-line-height: `1.5rem`;
--mat-form-field-container-text-size: 1rem;
--mat-form-field-container-text-tracking: `.5px`;

--mat-form-field-subscript-text-line-height: `1.125rem`;
--mat-form-field-subscript-text-size: .75rem;
--mat-form-field-subscript-text-tracking: `.4px`;
